### PR TITLE
Simulator: Add semicolon to end of SOCKET typedef.

### DIFF
--- a/TPMCmd/Simulator/src/TcpServer.c
+++ b/TPMCmd/Simulator/src/TcpServer.c
@@ -45,7 +45,7 @@
 #include <windows.h>
 #include <winsock.h>
 #else
-typedef int SOCKET
+typedef int SOCKET;
 #endif
 
 


### PR DESCRIPTION
This fixes a syntax error.

Signed-off-by: Philip Tricca <flihp@twobit.us>