### PR TITLE
Platform: Fix mispelled parameter to clock_gettime function.

### DIFF
--- a/TPMCmd/Platform/src/Clock.c
+++ b/TPMCmd/Platform/src/Clock.c
@@ -109,7 +109,7 @@ _plat__RealTime(
     // hopefully, this will work with most UNIX systems
     struct timespec     systime;
 //
-    clock_gettime(CLOCK_MONOTONIC, &systimets);
+    clock_gettime(CLOCK_MONOTONIC, &systime);
     time = (clock64_t)systime.tv_sec * 1000 + (systime.tv_nsec / 1000000);
 #endif
     return time;


### PR DESCRIPTION
The variable is declared as 'systime' but passed to clock_gettime as
'systimets'.

Signed-off-by: Philip Tricca <flihp@twobit.us>