### PR TITLE
tpm: Add SIXTY_FOUR_BIT_LONG to RADIX_BITS check.

### DIFF
--- a/TPMCmd/tpm/include/ossl/TpmToOsslMath.h
+++ b/TPMCmd/tpm/include/ossl/TpmToOsslMath.h
@@ -55,7 +55,8 @@
 
 // Make sure that the library is using the correct size for a crypt word
 #if    defined THIRTY_TWO_BIT && (RADIX_BITS != 32)  \
-    || defined SIXTY_FOUR_BIT && (RADIX_BITS != 64)
+    || ((defined SIXTY_FOUR_BIT_LONG || defined SIXTY_FOUR_BIT) \
+        && (RADIX_BITS != 64))
 #  error "Ossl library is using different radix"
 #endif
 


### PR DESCRIPTION
Builds on 64bit Linux don't have SIXTY_FOUR_BIT defined. The RADIX_BITS
sanity checks here then failed to detect the mismatch. Adding
SIXTY_FOUR_BIT_LONG to the check fixes this.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>