### PR TITLE
Implement autotools build for TPM and Platform code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -298,3 +298,32 @@ TPMCmd/OsslInclude/*
 # Wolf Build results 
 TPMCmd/WolfDebug/*
 TPMCmd/WolfRelease/*
+
+# Linux build files
+.deps/
+.dirstamp
+.libs/
+*.la
+*.lo
+*.log
+*.o
+*.pp
+*.swp
+*.trs
+Makefile
+Makefile.in
+aclocal.m4
+autom4te.cache/
+compile
+config.guess
+config.log
+config.status
+config.sub
+configure
+depcomp
+install-sh
+libtool
+ltmain.sh
+missing
+src.mk
+TPMCmd/tpm/src/libtpm.a

--- a/.gitignore
+++ b/.gitignore
@@ -326,4 +326,5 @@ libtool
 ltmain.sh
 missing
 src.mk
+TPMCmd/Platform/src/libplatform.a
 TPMCmd/tpm/src/libtpm.a

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: c
+dist: xenial
+compiler:
+  - gcc
+  - clang
+
+addons:
+  apt:
+    packages:
+    - autoconf-archive
+    - gcc-multilib
+
+env:
+  - HOST="i686-pc-linux-gnu" CFLAGS="-m32" LDFLAGS="-m32"
+  - HOST="x86_64-pc-linux-gnu"
+
+before_install:
+  - sudo dpkg --add-architecture i386
+  - sudo apt-get update
+  - sudo apt-get install libssl-dev:i386
+
+script:
+  - ./bootstrap
+  - ./configure --host=${HOST}
+  - make --jobs=$(($(nproc)*3/2)) distcheck

--- a/Makefile.am
+++ b/Makefile.am
@@ -37,9 +37,14 @@ PLATFORM_INC = -I $(srcdir)/TPMCmd/Platform/include \
 TPM_INC = -I $(srcdir)/TPMCmd/tpm/include \
     -I $(srcdir)/TPMCmd/tpm/include/prototypes
 
+libplatform = TPMCmd/Platform/src/libplatform.a
 libtpm = TPMCmd/tpm/src/libtpm.a
 
-noinst_LIBRARIES = $(libtpm)
+noinst_LIBRARIES = $(libplatform) $(libtpm)
+
+TPMCmd_Platform_src_libplatform_a_CFLAGS = $(EXTRA_CFLAGS) $(PLATFORM_INC) \
+    $(TPM_INC)
+TPMCmd_Platform_src_libplatform_a_SOURCES = $(PLATFORM_C) $(PLATFORM_H)
 
 TPMCmd_tpm_src_libtpm_a_CFLAGS = $(EXTRA_CFLAGS) $(PLATFORM_INC) $(TPM_INC) \
     $(LIBCRYPTO_CFLAGS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,46 @@
+## The copyright in this software is being made available under the BSD License,
+## included below. This software may be subject to other third party and
+## contributor rights, including patent rights, and no such rights are granted
+## under this license.
+##
+## Copyright (c) Intel Corporation
+##
+## All rights reserved.
+##
+## BSD License
+##
+## Redistribution and use in source and binary forms, with or without modification,
+## are permitted provided that the following conditions are met:
+##
+## Redistributions of source code must retain the above copyright notice, this list
+## of conditions and the following disclaimer.
+##
+## Redistributions in binary form must reproduce the above copyright notice, this
+## list of conditions and the following disclaimer in the documentation and/or
+## other materials provided with the distribution.
+##
+## THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ""AS IS""
+## AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+## IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+## DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+## ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+## (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+## LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+## ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+## (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+## SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+include src.mk
+
+PLATFORM_INC = -I $(srcdir)/TPMCmd/Platform/include \
+    -I $(srcdir)/TPMCmd/Platform/include/prototypes
+TPM_INC = -I $(srcdir)/TPMCmd/tpm/include \
+    -I $(srcdir)/TPMCmd/tpm/include/prototypes
+
+libtpm = TPMCmd/tpm/src/libtpm.a
+
+noinst_LIBRARIES = $(libtpm)
+
+TPMCmd_tpm_src_libtpm_a_CFLAGS = $(EXTRA_CFLAGS) $(PLATFORM_INC) $(TPM_INC) \
+    $(LIBCRYPTO_CFLAGS)
+TPMCmd_tpm_src_libtpm_a_SOURCES = $(TPM_C) $(TPM_H) $(PLATFORM_H)

--- a/TPMCmd/tpm/include/Implementation.h
+++ b/TPMCmd/tpm/include/Implementation.h
@@ -152,7 +152,13 @@
 
 // Table 0:7 - Defines for Implementation Values
 #define FIELD_UPGRADE_IMPLEMENTED       NO
+#if defined(__x86_64__) || defined(_WIN64)
+#define RADIX_BITS                      64
+#elif defined(__i386__) || defined(_WIN32)
 #define RADIX_BITS                      32
+#else
+#error "Unable to determine RADIX_BITS from compiler environment."
+#endif
 #define HASH_ALIGNMENT                  4
 #define SYMMETRIC_ALIGNMENT             4
 #ifdef USE_WOLFCRYPT

--- a/bootstrap
+++ b/bootstrap
@@ -46,6 +46,7 @@ src_listvar () {
 
 echo "Generating file lists: src.mk"
 (
+    src_listvar "TPMCmd/Platform" "*.c" "PLATFORM_C"
     src_listvar "TPMCmd/Platform" "*.h" "PLATFORM_H"
     src_listvar "TPMCmd/tpm" "*.c" "TPM_C"
     src_listvar "TPMCmd/tpm" "*.h" "TPM_H"

--- a/bootstrap
+++ b/bootstrap
@@ -1,0 +1,63 @@
+#!/usr/bin/env sh
+# The copyright in this software is being made available under the BSD License,
+# included below. This software may be subject to other third party and
+# contributor rights, including patent rights, and no such rights are granted
+# under this license.
+#
+# Copyright (c) Intel Corporation
+#
+# All rights reserved.
+#
+# BSD License
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ""AS IS""
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+AUTORECONF=${AUTORECONF:-autoreconf}
+
+# generate list of source files for use in Makefile.am
+# if you add new source files, you must run ./bootstrap again
+src_listvar () {
+    basedir=$1
+    suffix=$2
+    var=$3
+
+    find "${basedir}" -name "${suffix}" | LC_ALL=C sort | tr '\n' ' ' | (printf "${var} = " && cat)
+    echo ""
+}
+
+echo "Generating file lists: src.mk"
+(
+    src_listvar "TPMCmd/Platform" "*.h" "PLATFORM_H"
+    src_listvar "TPMCmd/tpm" "*.c" "TPM_C"
+    src_listvar "TPMCmd/tpm" "*.h" "TPM_H"
+) > src.mk
+
+echo "Setting up build"
+${AUTORECONF} --install --sym
+
+# A freshly checked out source tree will not build. VendorString.h must have
+# these symbols defined to build.
+echo "Setting default vendor strings"
+sed -i 's&^\/\/\(#define[[:space:]]\+FIRMWARE_V1.*\)&\1&;
+        s&^\/\/\(#define[[:space:]]\+MANUFACTURER.*\)&\1&;
+        s&^\/\/\(#define[[:space:]]\+VENDOR_STRING_1.*\)&\1&' \
+       TPMCmd/tpm/include/VendorString.h

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,64 @@
+dnl The copyright in this software is being made available under the BSD License,
+dnl included below. This software may be subject to other third party and
+dnl contributor rights, including patent rights, and no such rights are granted
+dnl under this license.
+dnl
+dnl Copyright (c) Intel Corporation
+dnl
+dnl All rights reserved.
+dnl
+dnl BSD License
+dnl
+dnl Redistribution and use in source and binary forms, with or without modification,
+dnl are permitted provided that the following conditions are met:
+dnl
+dnl Redistributions of source code must retain the above copyright notice, this list
+dnl of conditions and the following disclaimer.
+dnl
+dnl Redistributions in binary form must reproduce the above copyright notice, this
+dnl list of conditions and the following disclaimer in the documentation and/or
+dnl other materials provided with the distribution.
+dnl
+dnl THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ""AS IS""
+dnl AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+dnl IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+dnl DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+dnl ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+dnl (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+dnl LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+dnl ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+dnl (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+dnl SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+AC_INIT([ms-tpm-20-ref],
+        [0.1],
+        [https://github.com/microsoft/ms-tpm-20-ref/issues],
+        [],
+        [https://github.com/microsoft/ms-tpm-20-ref])
+AC_CONFIG_MACRO_DIR([m4])
+AC_PROG_CC
+AC_PROG_LN_S
+AC_PROG_RANLIB
+AM_INIT_AUTOMAKE([foreign subdir-objects])
+AC_CONFIG_FILES([Makefile])
+AC_SUBST([DISTCHECK_CONFIGURE_FLAGS],[$ac_configure_args])
+
+PKG_CHECK_MODULES([LIBCRYPTO], [libcrypto < 1.1 ])
+
+ADD_COMPILER_FLAG([-std=gnu11])
+ADD_COMPILER_FLAG([-Werror])
+ADD_COMPILER_FLAG([-Wall])
+ADD_COMPILER_FLAG([-Wformat-security])
+ADD_COMPILER_FLAG([-fstack-protector-all])
+ADD_COMPILER_FLAG([-fPIC])
+ADD_COMPILER_FLAG([-Wno-error=empty-body])
+ADD_COMPILER_FLAG([-Wno-error=expansion-to-defined])
+ADD_COMPILER_FLAG([-Wno-error=pointer-to-int-cast])
+ADD_COMPILER_FLAG([-Wno-error=missing-braces])
+
+ADD_LINK_FLAG([-Wl,--no-undefined])
+ADD_LINK_FLAG([-Wl,-z,noexecstack])
+ADD_LINK_FLAG([-Wl,-z,now])
+ADD_LINK_FLAG([-Wl,-z,relro])
+
+AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -55,6 +55,7 @@ ADD_COMPILER_FLAG([-Wno-error=empty-body])
 ADD_COMPILER_FLAG([-Wno-error=expansion-to-defined])
 ADD_COMPILER_FLAG([-Wno-error=pointer-to-int-cast])
 ADD_COMPILER_FLAG([-Wno-error=missing-braces])
+ADD_COMPILER_FLAG([-Wno-error=unused-result])
 
 ADD_LINK_FLAG([-Wl,--no-undefined])
 ADD_LINK_FLAG([-Wl,-z,noexecstack])

--- a/m4/flags.m4
+++ b/m4/flags.m4
@@ -1,0 +1,84 @@
+dnl The copyright in this software is being made available under the BSD License,
+dnl included below. This software may be subject to other third party and
+dnl contributor rights, including patent rights, and no such rights are granted
+dnl under this license.
+dnl
+dnl Copyright (c) Intel Corporation
+dnl
+dnl All rights reserved.
+dnl
+dnl BSD License
+dnl
+dnl Redistribution and use in source and binary forms, with or without modification,
+dnl are permitted provided that the following conditions are met:
+dnl
+dnl Redistributions of source code must retain the above copyright notice, this list
+dnl of conditions and the following disclaimer.
+dnl
+dnl Redistributions in binary form must reproduce the above copyright notice, this
+dnl list of conditions and the following disclaimer in the documentation and/or
+dnl other materials provided with the distribution.
+dnl
+dnl THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ""AS IS""
+dnl AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+dnl IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+dnl DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+dnl ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+dnl (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+dnl LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+dnl ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+dnl (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+dnl SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+dnl ADD_COMPILER_FLAG:
+dnl   A macro to add a CFLAG to the EXTRA_CFLAGS variable. This macro will
+dnl   check to be sure the compiler supprts the flag. Flags can be made
+dnl   mandatory (configure will fail).
+dnl $1: C compiler flag to add to EXTRA_CFLAGS.
+dnl $2: Set to "required" to cause configure failure if flag not supported..
+AC_DEFUN([ADD_COMPILER_FLAG],[
+    AX_CHECK_COMPILE_FLAG([$1],[
+        EXTRA_CFLAGS="$EXTRA_CFLAGS $1"
+        AC_SUBST([EXTRA_CFLAGS])],[
+        AS_IF([test x$2 != xrequired],[
+            AC_MSG_WARN([Optional CFLAG "$1" not supported by your compiler, continuing.])],[
+            AC_MSG_ERROR([Required CFLAG "$1" not supported by your compiler, aborting.])]
+        )],[
+        -Wall -Werror]
+    )]
+)
+dnl ADD_PREPROC_FLAG:
+dnl   Add the provided preprocessor flag to the EXTRA_CFLAGS variable. This
+dnl   macro will check to be sure the preprocessor supports the flag.
+dnl   The flag can be made mandatory by provideing the string 'required' as
+dnl   the second parameter.
+dnl $1: Preprocessor flag to add to EXTRA_CFLAGS.
+dnl $2: Set to "required" t ocause configure failure if preprocesor flag
+dnl     is not supported.
+AC_DEFUN([ADD_PREPROC_FLAG],[
+    AX_CHECK_PREPROC_FLAG([$1],[
+        EXTRA_CFLAGS="$EXTRA_CFLAGS $1"
+        AC_SUBST([EXTRA_CFLAGS])],[
+        AS_IF([test x$2 != xrequired],[
+            AC_MSG_WARN([Optional preprocessor flag "$1" not supported by your compiler, continuing.])],[
+            AC_MSG_ERROR([Required preprocessor flag "$1" not supported by your compiler, aborting.])]
+        )],[
+        -Wall -Werror]
+    )]
+)
+dnl ADD_LINK_FLAG:
+dnl   A macro to add a LDLAG to the EXTRA_LDFLAGS variable. This macro will
+dnl   check to be sure the linker supprts the flag. Flags can be made
+dnl   mandatory (configure will fail).
+dnl $1: linker flag to add to EXTRA_LDFLAGS.
+dnl $2: Set to "required" to cause configure failure if flag not supported.
+AC_DEFUN([ADD_LINK_FLAG],[
+    AX_CHECK_LINK_FLAG([$1],[
+        EXTRA_LDFLAGS="$EXTRA_LDFLAGS $1"
+        AC_SUBST([EXTRA_LDFLAGS])],[
+        AS_IF([test x$2 != xrequired],[
+            AC_MSG_WARN([Optional LDFLAG "$1" not supported by your linker, continuing.])],[
+            AC_MSG_ERROR([Required LDFLAG "$1" not supported by your linker, aborting.])]
+        )]
+    )]
+)


### PR DESCRIPTION
This is the minimum required to:
* build the code under `TPMCmd/tpm` as a static library called libtpm.a
* build the code under `TPMCmd/Platform` as a static library called libplatform.a
* automate 32 and 64bit builds using travis-ci

The only code changes required to do this are a minor change to a preprocessor macro to accommodate GCC and clang and the generation of the RADIX_BITS value from the compiler environment. The rest of this is just the addition of build script and config for the autotools.