### PR TITLE
Update CONTRIBUTING.md to include CLA

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,6 @@ Security sensitive bugs should be reported to secure@microsoft.com
 
 # Guideline for submitting changes:
 
-
 This repository tracks official TPM Library Specification releases and errata from
 the Trusted Computing Group:
 
@@ -27,3 +26,17 @@ the future evolution of the TPM specification and reference implementation
 should consider joining the Trusted Computing Group.  Information about
 membership and liaison programs is available at https://trustedcomputinggroup.org/membership/
 
+# Contributing
+
+This project welcomes contributions and suggestions. Most contributions require you to
+agree to a Contributor License Agreement (CLA) declaring that you have the right to,
+and actually do, grant us the rights to use your contribution. For details, visit
+https://cla.microsoft.com.
+
+When you submit a pull request, a CLA-bot will automatically determine whether you need
+to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the
+instructions provided by the bot. You will only need to do this once across all repositories using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


### PR DESCRIPTION
According to company policy, contributions to Microsoft open source projects have to be made under a contribution license