### PR TITLE
Fix issues compiling with GCC

### DIFF
--- a/TPMCmd/tpm/include/wolf/TpmToWolfHash.h
+++ b/TPMCmd/tpm/include/wolf/TpmToWolfHash.h
@@ -42,7 +42,10 @@
 
 #if HASH_LIB == WOLF
 
+#ifndef WOLFSSL_USER_SETTINGS
 #define WOLFSSL_USER_SETTINGS
+#endif
+
 #include <wolfSSL/wolfCrypt/sha.h>
 #include <wolfSSL/wolfCrypt/sha256.h>
 #include <wolfSSL/wolfCrypt/sha512.h>

--- a/TPMCmd/tpm/src/crypt/CryptEccData.c
+++ b/TPMCmd/tpm/src/crypt/CryptEccData.c
@@ -83,7 +83,7 @@
         } NAME = {BN_MIN_ALLOC(bytes), BYTES_TO_CRYPT_WORDS(bytes),{initializer}}
 // define how to transform a curve parameter address into an entry into an 
 // ECC_CURVE_DATA structure. 
-# define ECC_ENTRY(val, x)    (bigNum)&##val##_##x
+# define ECC_ENTRY(val, x)    (bigNum)&val##_##x
 
 ECC_CONST(ECC_ZERO, 0, 0);
 

--- a/TPMCmd/tpm/src/crypt/wolf/TpmToWolfMath.c
+++ b/TPMCmd/tpm/src/crypt/wolf/TpmToWolfMath.c
@@ -135,7 +135,7 @@ MathLibraryCompatibilityCheck(
     // Make sure the values are consistent
     cAssert(wolfTemp->used == (int)tpmTemp->size);
     for(i = 0; i < tpmTemp->size; i++)
-        cAssert(wolfTemp->d[i] == tpmTemp->d[i]);
+        cAssert(wolfTemp->dp[i] == tpmTemp->d[i]);
 }
 #endif
 


### PR DESCRIPTION
GCC is more pedantic about pre-processor concatenation, and it does not consider the ECC_ENTRY macro to be valid.

When compiling with GCC I'm also hitting a warning about redefining WOLFSSL_USER_SETTINGS.

MathLibraryCompatibilityCheck() also appears to have an error.
