### PR TITLE
Config flag fix + missing prototpye

### DIFF
--- a/TPMCmd/Simulator/src/TPMCmdp.c
+++ b/TPMCmd/Simulator/src/TPMCmdp.c
@@ -312,7 +312,7 @@ _rpc__RsaKeyCacheControl(
     int              state
     )
 {
-#ifdef USE_RSA_KEY_CACHE
+#if USE_RSA_KEY_CACHE
     RsaKeyCacheControl(state);
 #else
     NOT_REFERENCED(state);

--- a/TPMCmd/tpm/include/TpmBuildSwitches.h
+++ b/TPMCmd/tpm/include/TpmBuildSwitches.h
@@ -76,8 +76,8 @@
 // chosen big number math library. Not all ports use this.
 #if !defined LIBRARY_COMPATIBILITY_CHECK                                           \
         || LIBRARY_COMPATIBILITY_CHECK != YES
-#   undef LIBRARY_COMPATABILITY_CHECK
-#   define LIBRARY_COMPATABILITY_CHECK NO
+#   undef LIBRARY_COMPATIBILITY_CHECK
+#   define LIBRARY_COMPATIBILITY_CHECK NO
 #endif
 
 
@@ -168,7 +168,7 @@
 #       undef USE_RSA_KEY_CACHE
 #       define USE_RSA_KEY_CACHE YES
 #   endif
-#   if !defined USE_KEY_CACHE_FILE || USE_RSA_KEY_CACHE_FILE != NO
+#   if !defined USE_KEY_CACHE_FILE || USE_KEY_CACHE_FILE != NO
 #       undef USE_KEY_CACHE_FILE
 #       define USE_KEY_CACHE_FILE YES
 #   endif
@@ -182,7 +182,7 @@
 #else
 // Don't change these. They are the settings needed when not doing a simulation
 # define USE_RSA_KEY_CACHE NO
-# define USE_RSA_KEY_CACHE_FILE NO
+# define USE_KEY_CACHE_FILE NO
 # define USE_DEBUG_RNG NO
 #endif  // SIMULATION
 

--- a/TPMCmd/tpm/include/prototypes/MathOnByteBuffers_fp.h
+++ b/TPMCmd/tpm/include/prototypes/MathOnByteBuffers_fp.h
@@ -138,4 +138,11 @@ ShiftLeft(
     TPM2B       *value          // IN/OUT: value to shift and shifted value out
 );
 
+//*** IsNumeric()
+// Verifies that all the characters are simple numeric (0-9)
+BOOL
+IsNumeric(
+    TPM2B       *value          // IN: value to verify is a simple number
+);
+
 #endif  // _MATHONBYTEBUFFERS_FP_H_

--- a/TPMCmd/tpm/include/prototypes/RsaKeyCache_fp.h
+++ b/TPMCmd/tpm/include/prototypes/RsaKeyCache_fp.h
@@ -40,7 +40,7 @@
 #ifndef    _RSAKEYCACHE_FP_H_
 #define    _RSAKEYCACHE_FP_H_
 
-#if defined SIMULATION && defined USE_RSA_KEY_CACHE
+#if SIMULATION && USE_RSA_KEY_CACHE
 
 //*** RsaKeyCacheControl()
 // Used to enable and disable the RSA key cache.
@@ -55,6 +55,6 @@ GetCachedRsaKey(
     RAND_STATE          *rand               // IN: if not NULL, the deterministic
                                             //     RNG state
     );
-#endif  // defined SIMULATION && defined USE_RSA_KEY_CACHE
+#endif  // SIMULATION && USE_RSA_KEY_CACHE
 
 #endif  // _RSAKEYCACHE_FP_H_

--- a/TPMCmd/tpm/include/prototypes/TpmFail_fp.h
+++ b/TPMCmd/tpm/include/prototypes/TpmFail_fp.h
@@ -40,14 +40,12 @@
 #ifndef    _TPMFAIL_FP_H_
 #define    _TPMFAIL_FP_H_
 
-#if SIMULATION
 //*** SetForceFailureMode()
 // This function is called by the simulator to enable failure mode testing.
 LIB_EXPORT void
 SetForceFailureMode(
     void
     );
-#endif
 
 //*** TpmFail()
 // This function is called by TPM.lib when a failure occurs. It will set up the

--- a/TPMCmd/tpm/include/prototypes/TpmToOsslMath_fp.h
+++ b/TPMCmd/tpm/include/prototypes/TpmToOsslMath_fp.h
@@ -64,7 +64,7 @@ BigInitialized(
     bigConst            initializer
     );
 
-#ifdef LIBRARY_COMPATIBILITY_CHECK
+#if LIBRARY_COMPATIBILITY_CHECK
 void
 MathLibraryCompatibilityCheck(
     void

--- a/TPMCmd/tpm/src/crypt/CryptEccMain.c
+++ b/TPMCmd/tpm/src/crypt/CryptEccMain.c
@@ -38,7 +38,7 @@
 #ifdef TPM_ALG_ECC
 
 // This version requires that the new format for ECC data be used
-#ifndef USE_BN_ECC_DATA
+#if !USE_BN_ECC_DATA
 #error "Need to define USE_BN_ECC_DATA in Implementaion.h"
 #endif
 

--- a/TPMCmd/tpm/src/crypt/CryptRsa.c
+++ b/TPMCmd/tpm/src/crypt/CryptRsa.c
@@ -1165,7 +1165,7 @@ Exit:
     return (retVal != TPM_RC_SUCCESS) ? TPM_RC_SIGNATURE : TPM_RC_SUCCESS;
 }
 
-#if defined SIMULATION && defined USE_RSA_KEY_CACHE
+#if SIMULATION && USE_RSA_KEY_CACHE
 extern int s_rsaKeyCacheEnabled;
 int GetCachedRsaKey(OBJECT *key, RAND_STATE *rand);
 #define GET_CACHED_KEY(key, rand)                       \
@@ -1249,7 +1249,7 @@ CryptRsaGenerateKey(
     // Set the prime size for instrumentation purposes
     INSTRUMENT_SET(PrimeIndex, PRIME_INDEX(keySizeInBits / 2));
 
-#if defined SIMULATION && defined USE_RSA_KEY_CACHE
+#if SIMULATION && USE_RSA_KEY_CACHE
     if(GET_CACHED_KEY(rsaKey, rand))
         return TPM_RC_SUCCESS;
 #endif

--- a/TPMCmd/tpm/src/crypt/RsaKeyCache.c
+++ b/TPMCmd/tpm/src/crypt/RsaKeyCache.c
@@ -63,7 +63,7 @@
 
 #include "Tpm.h"
 
-#if defined SIMULATION && defined USE_RSA_KEY_CACHE
+#if SIMULATION && USE_RSA_KEY_CACHE
 #include  <stdio.h>
 
 #include "Platform_fp.h"
@@ -178,7 +178,7 @@ InitializeKeyCache(
     }
     rsaKey->publicArea.parameters.rsaDetail.keyBits = keySave;
     s_keyCacheLoaded = OK;
-#if defined SIMULATION && defined USE_RSA_KEY_CACHE && defined USE_KEY_CACHE_FILE
+#if SIMULATION && USE_RSA_KEY_CACHE && USE_KEY_CACHE_FILE
     if(OK)
     {
         FILE                *cacheFile;
@@ -215,7 +215,7 @@ KeyCacheLoaded(
                                             //     RNG state
     )
 {
-#if defined SIMULATION && defined USE_RSA_KEY_CACHE && defined USE_KEY_CACHE_FILE
+#if SIMULATION && USE_RSA_KEY_CACHE && USE_KEY_CACHE_FILE
     if(!s_keyCacheLoaded)
     {
         FILE            *cacheFile;
@@ -271,4 +271,4 @@ GetCachedRsaKey(
     }
     return s_keyCacheLoaded;
 }
-#endif  // defined SIMULATION && defined USE_RSA_KEY_CACHE
+#endif  // SIMULATION && USE_RSA_KEY_CACHE

--- a/TPMCmd/tpm/src/crypt/ossl/TpmToOsslMath.c
+++ b/TPMCmd/tpm/src/crypt/ossl/TpmToOsslMath.c
@@ -145,7 +145,7 @@ done:
 }
 #endif
 
-#ifdef LIBRARY_COMPATIBILITY_CHECK
+#if LIBRARY_COMPATIBILITY_CHECK
 void
 MathLibraryCompatibilityCheck(
     void 

--- a/TPMCmd/tpm/src/crypt/ossl/TpmToOsslSupport.c
+++ b/TPMCmd/tpm/src/crypt/ossl/TpmToOsslSupport.c
@@ -53,7 +53,7 @@ SupportLibInit(
     void
     )
 {
-#ifdef LIBRARY_COMPATIBILITY_CHECK
+#if LIBRARY_COMPATIBILITY_CHECK
     MathLibraryCompatibilityCheck();
 #endif
     return TRUE;

--- a/TPMCmd/tpm/src/crypt/wolf/TpmToWolfMath.c
+++ b/TPMCmd/tpm/src/crypt/wolf/TpmToWolfMath.c
@@ -112,7 +112,7 @@ MpInitialize(
     return toInit;
 }
 
-#ifdef LIBRARY_COMPATIBILITY_CHECK
+#if LIBRARY_COMPATIBILITY_CHECK
 //** MathLibraryCompatibililtyCheck()
 // This function is only used during development to make sure that the library
 // that is being referenced is using the same size of data structures as the TPM.

--- a/TPMCmd/tpm/src/crypt/wolf/TpmToWolfSupport.c
+++ b/TPMCmd/tpm/src/crypt/wolf/TpmToWolfSupport.c
@@ -51,7 +51,7 @@ SupportLibInit(
     void
     )
 {
-#ifdef LIBRARY_COMPATIBILITY_CHECK
+#if LIBRARY_COMPATIBILITY_CHECK
     MathLibraryCompatibilityCheck();
 #endif
     return TRUE;

--- a/TPMCmd/tpm/src/events/_TPM_Init.c
+++ b/TPMCmd/tpm/src/events/_TPM_Init.c
@@ -43,7 +43,7 @@ _TPM_Init(
 {
     g_powerWasLost = g_powerWasLost | _plat__WasPowerLost();
 
-#if defined SIMULATION && !defined NDEBUG
+#if SIMULATION && !defined NDEBUG
     // If power was lost and this was a simulation, put canary in RAM used by NV
     // so that uninitialized memory can be detected more easily
     if(g_powerWasLost)


### PR DESCRIPTION
Some of the config flags still use the original #ifdef style rather than the new #if yes/no format. It is not possible to disable some areas of code, leading to compile time warnings (missing prototypes etc).

SetForceFailureMode() is always called even if the functionality is disabled, so keep the prototype available.

IsNumeric() had no prototype, although it is also never used. Might be a candidate for removal?