### PR TITLE
Fix capitalization of wolfcrypt include statements for pure linux build.

### DIFF
--- a/TPMCmd/tpm/include/wolf/TpmToWolfHash.h
+++ b/TPMCmd/tpm/include/wolf/TpmToWolfHash.h
@@ -46,9 +46,9 @@
 #define WOLFSSL_USER_SETTINGS
 #endif
 
-#include <wolfSSL/wolfCrypt/sha.h>
-#include <wolfSSL/wolfCrypt/sha256.h>
-#include <wolfSSL/wolfCrypt/sha512.h>
+#include <wolfssl/wolfcrypt/sha.h>
+#include <wolfssl/wolfcrypt/sha256.h>
+#include <wolfssl/wolfcrypt/sha512.h>
 
 
 //***************************************************************

--- a/TPMCmd/tpm/include/wolf/TpmToWolfSym.h
+++ b/TPMCmd/tpm/include/wolf/TpmToWolfSym.h
@@ -42,8 +42,8 @@
 
 #if SYM_LIB == WOLF
 
-#include <wolfSSL/wolfCrypt/aes.h>
-#include <wolfSSL/wolfCrypt/des3.h>
+#include <wolfssl/wolfcrypt/aes.h>
+#include <wolfssl/wolfcrypt/des3.h>
 
 //***************************************************************
 //** Links to the wolfCrypt AES code


### PR DESCRIPTION
When the repo is cloned into the Windows filesystem, file names are case insensitive (even when accessed through WSL). However, if the repo is cloned straight into the WLS filesystem the files are left case sensitive.