### PR TITLE
Fixes found during fTPM Sample development.

### DIFF
--- a/TPMCmd/Platform/src/NVMem.c
+++ b/TPMCmd/Platform/src/NVMem.c
@@ -172,7 +172,7 @@ _plat__NVEnable(
     _plat__NvMemoryClear(0, NV_MEMORY_SIZE);
 
     // If the file exists
-    if(0 >= NvFileOpen("r+b"))
+    if(0 <= result)
     {
         long    fileSize = NvFileSize(SEEK_SET);    // get the file size and leave the
                                                     // file pointer at the start
@@ -184,7 +184,7 @@ _plat__NVEnable(
             NvFileCommit();     // for any other size, initialize it
     }
     // If NVChip file does not exist, try to create it for read/write. 
-    else if(0 >= NvFileOpen("w+b"))
+    else if(0 <= NvFileOpen("w+b"))
         NvFileCommit();             // Initialize the file
     assert(NULL != s_NvFile);       // Just in case we are broken for some reason.
 #endif

--- a/TPMCmd/Platform/src/NVMem.c
+++ b/TPMCmd/Platform/src/NVMem.c
@@ -172,7 +172,7 @@ _plat__NVEnable(
     _plat__NvMemoryClear(0, NV_MEMORY_SIZE);
 
     // If the file exists
-    if(0 <= result)
+    if(0 <= NvFileOpen("r+b"))
     {
         long    fileSize = NvFileSize(SEEK_SET);    // get the file size and leave the
                                                     // file pointer at the start

--- a/TPMCmd/Platform/src/NVMem.c
+++ b/TPMCmd/Platform/src/NVMem.c
@@ -204,7 +204,7 @@ _plat__NVDisable(
     )
 {
 #ifdef  FILE_BACKED_NV
-    if(NULL != s_NvFile);
+    if(NULL != s_NvFile)
         fclose(s_NvFile);    // Close NV file
     s_NvFile = NULL;        // Set file handle to NULL
 #endif

--- a/TPMCmd/tpm/src/crypt/CryptEccData.c
+++ b/TPMCmd/tpm/src/crypt/CryptEccData.c
@@ -83,7 +83,7 @@
         } NAME = {BN_MIN_ALLOC(bytes), BYTES_TO_CRYPT_WORDS(bytes),{initializer}}
 // define how to transform a curve parameter address into an entry into an 
 // ECC_CURVE_DATA structure. 
-# define ECC_ENTRY(val, x)    (bigNum)&##val##_##x
+# define ECC_ENTRY(val, x)    (bigNum)&val##_##x
 
 ECC_CONST(ECC_ZERO, 0, 0);
 
@@ -95,7 +95,7 @@ ECC_CONST(ECC_ZERO, 0, 0);
 TPM2B_BYTE_VALUE(1);
 TPM2B_1_BYTE_VALUE ECC_ZERO = {1, {0}};
 
-# define ECC_ENTRY(val, x)    &##val##_##x##.b
+# define ECC_ENTRY(val, x)    &val##_##x##.b
 
 #endif
 

--- a/TPMCmd/tpm/src/support/TpmFail.c
+++ b/TPMCmd/tpm/src/support/TpmFail.c
@@ -162,7 +162,12 @@ SetForceFailureMode(
     void
     )
 {
+#if SIMULATION
     g_forceFailureMode = TRUE;
+#else
+    _plat__Fail();
+#endif
+
     return;
 }
 


### PR DESCRIPTION
- Simulator fails to create a new NV backing file on first run. (NvFileOpen returns -1 on first call to indicate no file present, but 0 > -1 so it attempts to read from the file rather than creating it)
- GCC is more pedantic about preprocessor concatenations than VS. Each intermediate step between concatenations must also be a valid preprocessor statement.
- SetForceFailureMode() attempts to access g_forceFailureMode which is not available when SIMULATION=NO, call plat_Fail() instead.
- Simulation #ifdef references in the first commit has already been fixed upstream.