### PR TITLE
Remove SMAC.c from make files for fTPM

### DIFF
--- a/Samples/ARM32-FirmwareTPM/optee_ta/fTPM/lib/tpm/sub.mk
+++ b/Samples/ARM32-FirmwareTPM/optee_ta/fTPM/lib/tpm/sub.mk
@@ -181,7 +181,6 @@ srcs-y += tpm_symlink/TPMCmd/tpm/src/command/Symmetric/EncryptDecrypt_spt.c
 srcs-y += tpm_symlink/TPMCmd/tpm/src/command/Symmetric/Hash.c
 srcs-y += tpm_symlink/TPMCmd/tpm/src/command/Symmetric/HMAC.c
 srcs-y += tpm_symlink/TPMCmd/tpm/src/command/Symmetric/MAC.c
-srcs-y += tpm_symlink/TPMCmd/tpm/src/command/Symmetric/SMAC.c
 srcs-y += tpm_symlink/TPMCmd/tpm/src/command/Testing/GetTestResult.c
 srcs-y += tpm_symlink/TPMCmd/tpm/src/command/Testing/IncrementalSelfTest.c
 srcs-y += tpm_symlink/TPMCmd/tpm/src/command/Testing/SelfTest.c


### PR DESCRIPTION
Keep fTPM build infrastructure in line with effe676f1d1188579d886eebbc9e8fda46a800e3