### PR TITLE
Fix -Wexpansion-to-defined warning in SMAC_IMPLEMENTED

### DIFF
--- a/TPMCmd/tpm/include/CryptHash.h
+++ b/TPMCmd/tpm/include/CryptHash.h
@@ -75,7 +75,11 @@ typedef struct sequenceMethods {
     SMAC_END_METHOD           end;
 } SMAC_METHODS;
 
-#define SMAC_IMPLEMENTED (defined TPM_CC_MAC || defined TPM_CC_MAC_Start)
+#if defined(TPM_CC_MAC) || defined(TPM_CC_MAC_Start)
+#define SMAC_IMPLEMENTED 1
+#else
+#define SMAC_IMPLEMENTED 0
+#endif
 
 // These definitions are here because the SMAC state is in the union of hash states.
 typedef struct tpmCmacState {


### PR DESCRIPTION
This change fixes the following warning:

./lib/tpm/tpm_symlink/TPMCmd/tpm/include/prototypes/CryptSmac_fp.h:43:5: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
...
./lib/tpm/tpm_symlink/TPMCmd/tpm/include/CryptHash.h:118:5: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]

The definition of SMAC_IMPLEMENTED includes the term 'defined', which
triggers the warning. Implement equivalent logic that avoids the warning.
This warning occurs in the compilation of every file.