### PR TITLE
build: don't check for OpenSSL < 1.1 in autotools builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,7 @@ AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_FILES([Makefile])
 AC_SUBST([DISTCHECK_CONFIGURE_FLAGS],[$ac_configure_args])
 
-PKG_CHECK_MODULES([LIBCRYPTO], [libcrypto < 1.1 ])
+PKG_CHECK_MODULES([LIBCRYPTO], [libcrypto])
 AX_PTHREAD([], [AC_MSG_ERROR([requires pthread])])
 
 ADD_COMPILER_FLAG([-std=gnu11])


### PR DESCRIPTION
Commit 6cb570e90317c7927a0c6da86a27777376a9a433 added support for
OpenSSL 1.1.1+, therefore we no longer need to check that the libcrypto
version found by pkg_config is < 1.1.

Signed-off-by: Joshua Lock <joshua.g.lock@intel.com>