### PR TITLE
Fix to linux arm & arm64 build failure

### DIFF
--- a/TPMCmd/tpm/include/Implementation.h
+++ b/TPMCmd/tpm/include/Implementation.h
@@ -126,9 +126,9 @@
 
 // Table 0:7 - Defines for Implementation Values
 #define FIELD_UPGRADE_IMPLEMENTED       NO
-#if defined(__x86_64__) || defined(_WIN64) || defined(_M_X64) || defined(_M_ARM64)
+#if defined(__x86_64__) || defined(__x86_64) || defined(__amd64__) || defined(__amd64) || defined(_WIN64) || defined(_M_X64) || defined(_M_ARM64) || defined(__aarch64__)
 #define RADIX_BITS                      64
-#elif defined(__i386__) || defined(_WIN32) || defined(_M_IX86) || defined(_M_ARM)
+#elif defined(__i386__) || defined(__i386) || defined(i386) || defined(_WIN32) || defined(_M_IX86) || defined(_M_ARM) || defined(__arm__) || defined(__thumb__)
 #define RADIX_BITS                      32
 #else
 #error "Unable to determine RADIX_BITS from compiler environment."


### PR DESCRIPTION
We found that building stpm for linux arm & arm64 failing due to the GNU C architecture flags are not properly set. Up streaming these changes.

The defined flags are updated by referencing below,
https://sourceforge.net/p/predef/wiki/Architectures/

We verified the build working using yacto build process.