### PR TITLE
TPMCmd: Remove _CRYPT_HASH_C_

### DIFF
--- a/TPMCmd/tpm/include/Ltc/TpmToLtcHash.h
+++ b/TPMCmd/tpm/include/Ltc/TpmToLtcHash.h
@@ -59,10 +59,6 @@
 #define tpmHashStateSHA512_t          struct sha512_state
 #define tpmHashStateSHA384_t          struct sha512_state
 
-
-// The following defines are only needed by CryptHash.c
-#ifdef _CRYPT_HASH_C_
-
 // Define the interface between CryptHash.c to the functions provided by the 
 // library. For each method, define the calling parameters of the method and then 
 // define how the method is invoked in CryptHash.c.
@@ -161,9 +157,6 @@
 #define tpmHashStateCopy_SHA512     memcpy 
 #define tpmHashStateExport_SHA512   memcpy 
 #define tpmHashStateImport_SHA512   memcpy
-
-#endif // _CRYPT_HASH_C_
-
 
 // No special processing to initialize the LTC hash library
 #define LibHashInit()

--- a/TPMCmd/tpm/include/Ossl/TpmToOsslHash.h
+++ b/TPMCmd/tpm/include/Ossl/TpmToOsslHash.h
@@ -64,13 +64,6 @@
 #   error "The version of OpenSSL used by this code does not support SM3"
 #endif
 
-// The defines below are only needed when compiling CryptHash.c or CryptSmac.c. 
-// This isolation is primarily to avoid name space collision. However, if there 
-// is a real collision, it will likely show up when the linker tries to put things 
-// together.
-
-#ifdef _CRYPT_HASH_C_
-
 typedef BYTE          *PBYTE;
 typedef const BYTE    *PCBYTE;
 
@@ -170,8 +163,6 @@ typedef const BYTE    *PCBYTE;
 #define tpmHashStateCopy_SHA512     memcpy 
 #define tpmHashStateExport_SHA512   memcpy 
 #define tpmHashStateImport_SHA512   memcpy 
-
-#endif // _CRYPT_HASH_C_
 
 #define LibHashInit()
 // This definition would change if there were something to report

--- a/TPMCmd/tpm/include/Wolf/TpmToWolfHash.h
+++ b/TPMCmd/tpm/include/Wolf/TpmToWolfHash.h
@@ -73,13 +73,6 @@
 #   error "The version of WolfCrypt used by this code does not support SM3"
 #endif
 
-// The defines below are only needed when compiling CryptHash.c or CryptSmac.c. 
-// This isolation is primarily to avoid name space collision. However, if there 
-// is a real collision, it will likely show up when the linker tries to put things 
-// together.
-
-#ifdef _CRYPT_HASH_C_
-
 typedef BYTE          *PBYTE;
 typedef const BYTE    *PCBYTE;
 
@@ -181,8 +174,6 @@ typedef const BYTE    *PCBYTE;
 #define tpmHashStateCopy_SHA512     memcpy 
 #define tpmHashStateExport_SHA512   memcpy 
 #define tpmHashStateImport_SHA512   memcpy 
-
-#endif // _CRYPT_HASH_C_
 
 #define LibHashInit()
 // This definition would change if there were something to report

--- a/TPMCmd/tpm/src/crypt/CryptCmac.c
+++ b/TPMCmd/tpm/src/crypt/CryptCmac.c
@@ -39,7 +39,6 @@
 // encryption functions of the selected symmetric cryptographic library.
 
 //** Includes, Defines, and Typedefs
-#define _CRYPT_HASH_C_
 #include "Tpm.h"
 #include "CryptSym.h"
 

--- a/TPMCmd/tpm/src/crypt/CryptHash.c
+++ b/TPMCmd/tpm/src/crypt/CryptHash.c
@@ -37,8 +37,6 @@
 // This file contains implementation of cryptographic functions for hashing.
 //
 //** Includes, Defines, and Types
-
-#define _CRYPT_HASH_C_
 #include "Tpm.h"
 #include "CryptHash_fp.h"
 #include "CryptHash.h"

--- a/TPMCmd/tpm/src/crypt/CryptSmac.c
+++ b/TPMCmd/tpm/src/crypt/CryptSmac.c
@@ -39,7 +39,6 @@
 // encryption functions of the selected symmetric cryptographic library.
 
 //** Includes, Defines, and Typedefs
-#define _CRYPT_HASH_C_
 #include "Tpm.h"
 
 #if SMAC_IMPLEMENTED


### PR DESCRIPTION
The TpmTo*Hash files preform bespoke isolation to prevent name
collisions, but this is not necessary to make the project build.

As the (now deleted) comment says, if there is a real collision, the
linker will figure it out. Helps address #33

Signed-off-by: Joe Richey <joerichey@google.com>