### PR TITLE
TPMCmd: Remove invalid CLOCK_UPDATE_MASK

### DIFF
--- a/TPMCmd/tpm/src/command/ClockTimer/ClockSet.c
+++ b/TPMCmd/tpm/src/command/ClockTimer/ClockSet.c
@@ -48,8 +48,6 @@ TPM2_ClockSet(
     ClockSet_In     *in             // IN: input parameter list
     )
 {
-#define CLOCK_UPDATE_MASK  ~((1ULL << NV_CLOCK_UPDATE_INTERVAL)- 1)
-
 // Input Validation
     // new time can not be bigger than 0xFFFF000000000000 or smaller than
     // current clock


### PR DESCRIPTION
`CLOCK_UPDATE_MASK` was moved to `TimeClockUpdate` and its value was
changed. However, during this move, the `#define CLOCK_UPDATE_MASK`
was left in. Now it does nothing and has the wrong value.

It should be removed. Note that this will make the content of `ClockSet.c` differ from the code in the specification. However, the current code is already differs from the spec code, see `RETURN_IF_NV_IS_NOT_AVAILABLE`.

Signed-off-by: Joe Richey <joerichey@google.com>