### PR TITLE
Use appropriate error for incorrect reserved bits in TPMA structures

### DIFF
--- a/TPMCmd/tpm/src/support/TableDrivenMarshal.c
+++ b/TPMCmd/tpm/src/support/TableDrivenMarshal.c
@@ -425,7 +425,7 @@ Unmarshal(
                                     buffer, size, &mask)))
             {
                 if((mask & amt->attributeMask) != 0)
-                    result = TPM_RC_ATTRIBUTES;
+                    result = TPM_RC_RESERVED_BITS;
             }
             break;
         }


### PR DESCRIPTION
According to the [TPM 2.0 Library specification, Part 2 (rev. 1.38), Table 2](https://www.trustedcomputinggroup.org/wp-content/uploads/TPM-Rev-2.0-Part-2-Structures-01.38.pdf#page=37), a `TPM_RC_RESERVED_BITS` error shall be used if "a non-zero value was found in a reserved field of an attribute structure (TPMA_)". This is done correctly when compiling with `TABLE_DRIVEN_MARSHAL=NO`, cf. [`Marshal.c`](https://github.com/microsoft/ms-tpm-20-ref/blob/39e7306e235a6b2e09e454af08de285388e7a4b4/TPMCmd/tpm/src/support/Marshal.c#L624), but for `TABLE_DRIVEN_MARSHAL=YES` the incorrect error `TPM_RC_ATTRIBUTES` is used instead.

This issue came up when experimenting with using the simulator for tpm2-tss (cf. https://github.com/tpm2-software/tpm2-tss/pull/1544) because it caused a test failure in [`test/tpmclient/tpmclient.int`](https://github.com/tpm2-software/tpm2-tss/blob/c8e90f2d88c137ac2402ff14537d609e24225078/test/tpmclient/tpmclient.int.c#L311-L316).