### PR TITLE
fix compilation when SIMULATION is set to NO

### DIFF
--- a/TPMCmd/Simulator/src/TPMCmdp.c
+++ b/TPMCmd/Simulator/src/TPMCmdp.c
@@ -139,7 +139,9 @@ _rpc__ForceFailureMode(
     void
     )
 {
+#if SIMULATION
     SetForceFailureMode();
+#endif
     return;
 }
 


### PR DESCRIPTION
SetForceFailureMode() is not compiled in tpm/src/support/TpmFail.c
unless SIMULATION is set to TRUE, let's not try calling it when
compiling in for simulation disabled.