### PR TITLE
Add support for ppc64le and s390x & enable related CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
 
 arch:
   - amd64
+  - arm64
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,36 @@
 language: c
 dist: bionic
 compiler:
-  - gcc
   - clang
+  - gcc
 
 addons:
   apt:
     packages:
     - autoconf-archive
-    - gcc-multilib
 
-env:
-  - HOST="i686-pc-linux-gnu" CFLAGS="-m32" LDFLAGS="-m32"
-  - HOST="x86_64-pc-linux-gnu"
+arch:
+  - amd64
+
+matrix:
+  include:
+    - compiler: clang
+      env: CONF_OPT="--host=i686-pc-linux-gnu" CFLAGS="-m32" LDFLAGS="-m32"
+    - compiler: gcc
+      env: CONF_OPT="--host=i686-pc-linux-gnu" CFLAGS="-m32" LDFLAGS="-m32"
 
 before_install:
-  - sudo dpkg --add-architecture i386
-  - sudo apt-get update
-  - sudo apt-get install libssl-dev:i386
+  - |
+    if [ $LDFLAGS = "-m32" ]; then
+        sudo dpkg --add-architecture i386
+        sudo apt-get update
+        sudo apt-get install gcc-multilib libssl-dev:i386
+    fi
 
 before_script:
   - cd TPMCmd
 
 script:
   - ./bootstrap
-  - ./configure --host=${HOST}
+  - ./configure ${CONF_OPT}
   - make --jobs=$(($(nproc)*3/2)) distcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
 arch:
   - amd64
   - arm64
+  - ppc64le
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ arch:
   - amd64
   - arm64
   - ppc64le
+  - s390x
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-dist: xenial
+dist: bionic
 compiler:
   - gcc
   - clang

--- a/TPMCmd/tpm/include/LibSupport.h
+++ b/TPMCmd/tpm/include/LibSupport.h
@@ -42,7 +42,7 @@
 #ifndef RADIX_BITS
 #   if defined(__x86_64__) || defined(__x86_64)                                         \
         || defined(__amd64__) || defined(__amd64) || defined(_WIN64) || defined(_M_X64) \
-        || defined(_M_ARM64) || defined(__aarch64__)
+        || defined(_M_ARM64) || defined(__aarch64__) || defined(__PPC64__)
 #       define RADIX_BITS                      64
 #   elif defined(__i386__) || defined(__i386) || defined(i386)                          \
         || defined(_WIN32) || defined(_M_IX86)                                          \

--- a/TPMCmd/tpm/include/LibSupport.h
+++ b/TPMCmd/tpm/include/LibSupport.h
@@ -42,7 +42,8 @@
 #ifndef RADIX_BITS
 #   if defined(__x86_64__) || defined(__x86_64)                                         \
         || defined(__amd64__) || defined(__amd64) || defined(_WIN64) || defined(_M_X64) \
-        || defined(_M_ARM64) || defined(__aarch64__) || defined(__PPC64__)
+        || defined(_M_ARM64) || defined(__aarch64__) || defined(__PPC64__) \
+        || defined(__s390x__)
 #       define RADIX_BITS                      64
 #   elif defined(__i386__) || defined(__i386) || defined(i386)                          \
         || defined(_WIN32) || defined(_M_IX86)                                          \


### PR DESCRIPTION
Updating the travis-ci build worker to the latest worker image allows us to use the 'arch' element in the .travis.yml file. This allows us to do builds on arm64, ppc64le and s390x architectures. Support for the PPC64 and s390x architectures required minor changes to LibSupport.h.