### PR TITLE
Unconditionally run fseek in NvFileSize.

### DIFF
--- a/TPMCmd/Platform/src/NVMem.c
+++ b/TPMCmd/Platform/src/NVMem.c
@@ -120,7 +120,9 @@ NvFileSize(
 //
     assert(NULL != s_NvFile);
 
-    assert(fseek(s_NvFile, 0, SEEK_END) == 0);
+    int fseek_result = fseek(s_NvFile, 0, SEEK_END);
+    NOT_REFERENCED(fseek_result); // Fix compiler warning for NDEBUG
+    assert(fseek_result == 0);
     fileSize = ftell(s_NvFile);
     assert(fileSize >= 0);
     switch(leaveAt)


### PR DESCRIPTION
The line

```
assert(fseek(s_NvFile, 0, SEEK_END) == 0);
```

is not run in NDEBUG mode, due to asserts being removed. However, fseek still has to be run for ftell to properly report the complete file size in NvFileSize. This separates out the fseek call so it works in NDEBUG and DEBUG modes.