### PR TITLE
Support compilation on and for Mac OS X systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,18 @@ Follows the common `./bootstrap && ./configure && make` convention.
 Note that autotools scripts require the following prerequisite packages: `autoconf-archive`, `pkg-config`, and sometimes `build-essential` and `automake`. Their absence is not automatically detected. The build also needs `gcc` and `libssl-dev` packages.
 
 Similarly to the Windows build, if you enable SM{2,3,4} algorithms in `TpmProfile.h`, the build may fail because of missing `SM{2,3,4}.h` headers. In this case you will need to manually copy them over from OpenSSL’s `include/crypt` folder.
+
+## Mac OS X build
+
+As with the Linux build, use `./bootstrap`, `./configure`, and `make`.
+If you used Homebrew to install OpenSSL, you may need to include its path in `PKG_CONFIG_PATH`.
+OS X compilers treat uninitialized global variables as
+[common symbols](https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/MachOTopics/1-Articles/executing_files.html),
+which can be eliminated with the `-fno-common` compiler option.
+Future updates to the autotools configurations may automate one or both of these steps.
+
+```
+./bootstrap
+PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig" EXTRA_CFLAGS=-fno-common ./configure
+make
+```

--- a/TPMCmd/Simulator/include/prototypes/Simulator_fp.h
+++ b/TPMCmd/Simulator/include/prototypes/Simulator_fp.h
@@ -43,7 +43,7 @@
 //** From TcpServer.c
 
 #ifdef _MSC_VER
-#elif defined(__unix__)
+#elif defined(__unix__) || defined(__APPLE__)
 #endif
 
 //*** PlatformServer()
@@ -156,7 +156,7 @@ TpmServer(
 //** From TPMCmdp.c
 
 #ifdef _MSC_VER
-#elif defined(__unix__)
+#elif defined(__unix__) || defined(__APPLE__)
 #endif
 
 //*** Signal_PowerOn()

--- a/TPMCmd/Simulator/src/TPMCmdp.c
+++ b/TPMCmd/Simulator/src/TPMCmdp.c
@@ -48,7 +48,7 @@
 #   include <windows.h>
 #   include <winsock.h>
 #   pragma warning(pop)
-#elif defined(__unix__)
+#elif defined(__unix__) || defined(__APPLE__)
 #   include "BaseTypes.h"   // on behalf of TpmFail_fp.h
     typedef int SOCKET;
 #else

--- a/TPMCmd/Simulator/src/TPMCmds.c
+++ b/TPMCmd/Simulator/src/TPMCmds.c
@@ -50,7 +50,7 @@
 #   include <windows.h>
 #   include <winsock.h>
 #   pragma warning(pop)
-#elif defined(__unix__)
+#elif defined(__unix__) || defined(__APPLE__)
 #   define _strcmpi strcasecmp
     typedef int SOCKET;
 #else

--- a/TPMCmd/Simulator/src/TcpServer.c
+++ b/TPMCmd/Simulator/src/TcpServer.c
@@ -48,7 +48,7 @@
 #   include <winsock.h>
 #   pragma warning(pop)
     typedef int socklen_t;
-#elif defined(__unix__)
+#elif defined(__unix__) || defined(__APPLE__)
 #   include <string.h>
 #   include <unistd.h>
 #   include <errno.h>

--- a/TPMCmd/bootstrap
+++ b/TPMCmd/bootstrap
@@ -60,7 +60,7 @@ ${AUTORECONF} --install --sym
 # A freshly checked out source tree will not build. VendorString.h must have
 # these symbols defined to build.
 echo "Setting default vendor strings"
-sed -i 's&^\/\/\(#define[[:space:]]\+FIRMWARE_V1.*\)&\1&;
+sed -i.bak 's&^\/\/\(#define[[:space:]]\+FIRMWARE_V1.*\)&\1&;
         s&^\/\/\(#define[[:space:]]\+MANUFACTURER.*\)&\1&;
         s&^\/\/\(#define[[:space:]]\+VENDOR_STRING_1.*\)&\1&' \
-       tpm/include/VendorString.h
+       tpm/include/VendorString.h && rm tpm/include/VendorString.h.bak


### PR DESCRIPTION
This PR adds some minor updates to autotools configuration and target platform `#ifdefs` to enable compilation on Mac OS X. It also adds a section to the README for how to compile on OS X by passing a couple of extra options to `configure`. Not being an expert on the autotools, I assume this could eventually be done automatically in either `configure.ac` or `Makefile.am`

- Tested on an x86_64 system with Mac OS X
- Tested on an x86_64 system with Debian Linux