### PR TITLE
[Windows][VS2019] Fix C4061

### DIFF
--- a/TPMCmd/tpm/src/command/Startup/Startup.c
+++ b/TPMCmd/tpm/src/command/Startup/Startup.c
@@ -186,6 +186,7 @@ TPM2_Startup(
                 gr.clearCount++;
                 gr.restartCount++;
                 break;
+            case SU_RESET:
             default:
                 // Reset object context ID to 0
                 gr.objectContextID = 0;


### PR DESCRIPTION
When building with VS2019, it will fail at the C4061 warning, and by default Visual Studio treated the warnings as errors (see below). This change is to fallback the missing SU_RESET handling to the `default` case.

```
Build FAILED.

"c:\workspace\ms-tpm-20-ref\TPMCmd\simulator.sln" (default target) (1) ->
"c:\workspace\ms-tpm-20-ref\TPMCmd\simulator\simulator.vcxproj" (default target) (2) ->
"c:\workspace\ms-tpm-20-ref\TPMCmd\tpm\TPM.vcxproj" (default target) (4) ->
(ClCompile target) ->
  cl : command line warning D9035: option 'Gm' has been deprecated and will be removed in a future release [c:\workspac
e\ms-tpm-20-ref\TPMCmd\tpm\TPM.vcxproj]
  c:\workspace\ms-tpm-20-ref\TPMCmd\tpm\src\command\Startup\Startup.c(220,9): warning C4061: enumerator 'SU_RESET' in s
witch of enum 'STARTUP_TYPE' is not explicitly handled by a case label [c:\workspace\ms-tpm-20-ref\TPMCmd\tpm\TPM.vcxpr
oj]


"c:\workspace\ms-tpm-20-ref\TPMCmd\simulator.sln" (default target) (1) ->
"c:\workspace\ms-tpm-20-ref\TPMCmd\simulator\simulator.vcxproj" (default target) (2) ->
"c:\workspace\ms-tpm-20-ref\TPMCmd\tpm\TPM.vcxproj" (default target) (4) ->
(ClCompile target) ->
  c:\workspace\ms-tpm-20-ref\TPMCmd\tpm\src\command\Startup\Startup.c(220,9): error C2220: the following warning is tre
ated as an error [c:\workspace\ms-tpm-20-ref\TPMCmd\tpm\TPM.vcxproj]

    2 Warning(s)
    1 Error(s)
```