### PR TITLE
Fix twos-complement arithmetic for PolicyNV

### DIFF
--- a/TPMCmd/tpm/src/support/MathOnByteBuffers.c
+++ b/TPMCmd/tpm/src/support/MathOnByteBuffers.c
@@ -101,12 +101,9 @@ SignedCompareB(
     {
         return signA - signB;
     }
-    if(signA == 1)
-        // do unsigned compare function
-        return UnsignedCompareB(aSize, a, bSize, b);
-    else
-        // do unsigned compare the other way
-        return 0 - UnsignedCompareB(aSize, a, bSize, b);
+    // Twos-complement arithmetic is the same as unsigned arithmetic if the
+    // sign bits are the same.
+    return UnsignedCompareB(aSize, a, bSize, b);
 }
 
 //*** ModExpB


### PR DESCRIPTION
This looks like the right fix to #57 to my eyes.

NOTE: I do not have access to LibTester, so I have not been able to validate this change. Even if this does not break existing LibTester tests, I'd like to introduce regression tests to LibTester to catch this.