### PR TITLE
Fix compiler warnings which may be treated as errors

### DIFF
--- a/TPMCmd/tpm/include/CompilerDependencies.h
+++ b/TPMCmd/tpm/include/CompilerDependencies.h
@@ -93,7 +93,9 @@ __pragma(warning(pop))
 #ifndef WINAPI
 #   define WINAPI
 #endif
+#ifndef __pragma
 #   define __pragma(x)
+#endif
 #   define REVERSE_ENDIAN_16(_Number) __builtin_bswap16(_Number)
 #   define REVERSE_ENDIAN_32(_Number) __builtin_bswap32(_Number)
 #   define REVERSE_ENDIAN_64(_Number) __builtin_bswap64(_Number)

--- a/TPMCmd/tpm/include/Global.h
+++ b/TPMCmd/tpm/include/Global.h
@@ -1223,7 +1223,7 @@ EXTERN UINT32           s_decryptSessionIndex;
 EXTERN UINT32           s_auditSessionIndex;
 
 // The cpHash for command audit
-#ifdef  TPM_CC_GetCommandAuditDigest
+#if  CC_GetCommandAuditDigest
 EXTERN TPM2B_DIGEST    s_cpHashForCommandAudit;
 #endif
 

--- a/TPMCmd/tpm/src/main/SessionProcess.c
+++ b/TPMCmd/tpm/src/main/SessionProcess.c
@@ -1490,7 +1490,7 @@ CheckAuthSession(
     return result;
 }
 
-#ifdef  TPM_CC_GetCommandAuditDigest
+#if  CC_GetCommandAuditDigest
 //*** CheckCommandAudit()
 // This function is called before the command is processed if audit is enabled
 // for the command. It will check to see if the audit can be performed and
@@ -1636,7 +1636,7 @@ ParseSessionBuffer(
                 return RcSafeAddToResult(result, errorIndex);
         }
     }
-#ifdef  TPM_CC_GetCommandAuditDigest
+#if  CC_GetCommandAuditDigest
     // Check if the command should be audited. Need to do this before any parameter
     // encryption so that the cpHash for the audit is correct
     if(CommandAuditIsRequired(command->index))
@@ -1692,7 +1692,9 @@ CheckAuthNoSession(
     )
 {
     UINT32 i;
+#if  CC_GetCommandAuditDigest
     TPM_RC           result = TPM_RC_SUCCESS;
+#endif
 //
     // Check if the command requires authorization
     for(i = 0; i < command->handleNum; i++)
@@ -1700,7 +1702,7 @@ CheckAuthNoSession(
         if(CommandAuthRole(command->index, i) != AUTH_NONE)
             return TPM_RC_AUTH_MISSING;
     }
-#ifdef  TPM_CC_GetCommandAuditDigest
+#if  CC_GetCommandAuditDigest
     // Check if the command should be audited.
     if(CommandAuditIsRequired(command->index))
     {
@@ -1818,7 +1820,7 @@ Audit(
     return;
 }
 
-#ifdef  TPM_CC_GetCommandAuditDigest
+#if  CC_GetCommandAuditDigest
 //*** CommandAudit()
 // This function updates the command audit digest.
 static void

--- a/TPMCmd/tpm/src/support/TpmSizeChecks.c
+++ b/TPMCmd/tpm/src/support/TpmSizeChecks.c
@@ -41,7 +41,9 @@
 #if RUNTIME_SIZE_CHECKS
 
 
+#if DEBUG
 static      int once = 0;
+#endif
 
 //** TpmSizeChecks()
 // This function is used during the development process to make sure that the


### PR DESCRIPTION
CompilerDependencies.h: __pragma is commonly defined in RTOS used as
part of various firmware platforms. Only define it if it isn't already
defined.

TpmSizeChecks.c: `once` is always defined, but is only used #if DEBUG.
This can cause "defined but not used" compiler errors.