### PR TITLE
Add ALG_SHA512 enable support.

### DIFF
--- a/TPMCmd/tpm/include/CryptHash.h
+++ b/TPMCmd/tpm/include/CryptHash.h
@@ -133,6 +133,7 @@ typedef struct SMAC_STATE {
         IF_IMPLEMENTED_SHA1(op)     \
         IF_IMPLEMENTED_SHA256(op)   \
         IF_IMPLEMENTED_SHA384(op)   \
+        IF_IMPLEMENTED_SHA512(op)   \
         IF_IMPLEMENTED_SM3_256(op)  \
         IF_IMPLEMENTED_SHA3_256(op) \
         IF_IMPLEMENTED_SHA3_384(op) \

--- a/TPMCmd/tpm/include/Ossl/TpmToOsslHash.h
+++ b/TPMCmd/tpm/include/Ossl/TpmToOsslHash.h
@@ -192,7 +192,7 @@ typedef const BYTE    *PCBYTE;
 #define tpmHashEnd_SHA512           SHA512_Final
 #define tpmHashStateCopy_SHA512     memcpy 
 #define tpmHashStateExport_SHA512   memcpy 
-#define tpmHashStateImport_SHA_512  memcpy 
+#define tpmHashStateImport_SHA512   memcpy 
 #define tpmHashStart_SM3_256        sm3_init
 #define tpmHashData_SM3_256         sm3_update
 #define tpmHashEnd_SM3_256          sm3_final


### PR DESCRIPTION
#65 

This patch can support enabling ALG_SHA512 without changing
CryptHash.h and TpmToOsslHash.h

