### PR TITLE
fTPM: add enum to ta flags

### DIFF
--- a/Samples/ARM32-FirmwareTPM/optee_ta/fTPM/user_ta_header_defines.h
+++ b/Samples/ARM32-FirmwareTPM/optee_ta/fTPM/user_ta_header_defines.h
@@ -44,7 +44,7 @@
 
 #define TA_UUID                     TA_FTPM_UUID
 
-#define TA_FLAGS                    (TA_FLAG_SINGLE_INSTANCE | TA_FLAG_INSTANCE_KEEP_ALIVE)
+#define TA_FLAGS                    (TA_FLAG_SINGLE_INSTANCE | TA_FLAG_INSTANCE_KEEP_ALIVE | TA_FLAG_DEVICE_ENUM_SUPP)
 #define TA_STACK_SIZE               (64 * 1024)
 #define TA_DATA_SIZE                (32 * 1024)
 


### PR DESCRIPTION
If we compile this TA into OPTEE-OS we need to define a flag that this TA can be discovered on the optee bus.


---
move https://github.com/microsoft/MSRSec/pull/34 here.