### PR TITLE
TpmFailureMode: Add missing request size checks

### DIFF
--- a/TPMCmd/tpm/src/support/TpmFail.c
+++ b/TPMCmd/tpm/src/support/TpmFail.c
@@ -195,6 +195,8 @@ void TpmFailureMode(uint32_t        inRequestSize,    // IN: command buffer size
         goto FailureModeReturn;
     if(header.tag != TPM_ST_NO_SESSIONS || header.size < 10)
         goto FailureModeReturn;
+    if(header.size != inRequestSize || header.size > MAX_COMMAND_SIZE)
+        goto FailureModeReturn;
     switch(header.code)
     {
         case TPM_CC_GetTestResult:

--- a/TPMCmd/tpm/src/support/TpmFail.c
+++ b/TPMCmd/tpm/src/support/TpmFail.c
@@ -184,8 +184,9 @@ void TpmFailureMode(uint32_t        inRequestSize,    // IN: command buffer size
     UINT8* buffer = inRequest;
     INT32  size   = inRequestSize;
 
-    // If there is no command buffer, then just return TPM_RC_FAILURE
-    if(inRequestSize == 0 || inRequest == NULL)
+    // If there is no command buffer or it is too small,
+    // then just return TPM_RC_FAILURE
+    if(inRequestSize < 10 || inRequest == NULL)
         goto FailureModeReturn;
     // If the header is not correct for TPM2_GetCapability() or
     // TPM2_GetTestResult() then just return the in failure mode response;


### PR DESCRIPTION
This is harmless, but is inconsistent with the non-failure case.

The second commit doesn’t change the TPM’s observable behavior.  However, when combined with the first commit, it would allow the bounds checks in `TpmFail.c`’s `Unmarshal16()` and `Unmarshal32()` to be omitted, or even replacing these functions with `BYTE_ARRAY_TO_UINT16()` and `BYTE_ARRAY_TO_UINT32()` respectively.  I did not make this change as it would be a slightly larger refactor.  I’m fine with keeping the second commit, dropping it entirely, or squashing it into the first commit.